### PR TITLE
Indent code properly

### DIFF
--- a/coarray.f90
+++ b/coarray.f90
@@ -1,16 +1,16 @@
-      program main
-      implicit none
-      integer, allocatable :: A(:)[:]
-      integer :: B
-      if (num_images()<2) stop 1
-      ! allocate from the shared heap
-      allocate(A(1)[*])
-      B = 134;
-      ! store contents of local B at PE 0 into A at PE 1
-      if (this_image().eq.0) A(1)[1] = B
-      ! global synchronization of execution and data
-      sync all
-      ! observe the result of the store
-      if (this_image().eq.1) print*,'A@1=',A(1)[1]
-      deallocate(A)
-      end program main
+program main
+  implicit none
+  integer, allocatable :: A(:)[:]
+  integer :: B
+  if (num_images()<2) stop 1
+  ! allocate from the shared heap
+  allocate(A(1)[*])
+  B = 134
+  ! store contents of local B at PE 0 into A at PE 1
+  if (this_image().eq.0) A(1)[1] = B
+  ! global synchronization of execution and data
+  sync all
+  ! observe the result of the store
+  if (this_image().eq.1) print*,'A@1=',A(1)[1]
+  deallocate(A)
+end program main


### PR DESCRIPTION
Fortran supports two indentation styles -- "fixed format" for backward compatibility (Fortran 77), and "free format" (the modern way). Usually, the file suffix indicates the source code format, and `.f90` indicates free format.

In free format, lines can be indented as you wish, as e.g. in C. I copy-pasted the code into an emacs buffer and let it indent the buffer.

I also removed a superfluous trailing semicolon.
